### PR TITLE
Apply memory leak and CVE-2023-38545 patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 boringssl/*
 curl/*
 _deps/*
+.vs/*

--- a/patch/curl-CVE-2023-38545.patch
+++ b/patch/curl-CVE-2023-38545.patch
@@ -1,0 +1,17 @@
+diff -u1 -Nar curl-8.1.1/lib/socks.c curl-8.1.1-patched/lib/socks.c
+--- curl-8.1.1/lib/socks.c	2023-05-22 19:15:11.000000000 +0300
++++ curl-8.1.1-patched/lib/socks.c	2024-03-03 13:32:42.814284316 +0200
+@@ -590,5 +590,5 @@
+     if(!socks5_resolve_local && hostname_len > 255) {
+-      infof(data, "SOCKS5: server resolving disabled for hostnames of "
+-            "length > 255 [actual len=%zu]", hostname_len);
+-      socks5_resolve_local = TRUE;
++      failf(data, "SOCKS5: the destination hostname is too long to be "
++            "resolved remotely by the proxy.");
++      return CURLPX_LONG_HOSTNAME;
+     }
+@@ -906,3 +906,3 @@
+         socksreq[len++] = 3;
+-        socksreq[len++] = (char) hostname_len; /* one byte address length */
++        socksreq[len++] = (unsigned char) hostname_len; /* one byte length */
+         memcpy(&socksreq[len], sx->hostname, hostname_len); /* w/o NULL */

--- a/patch/curl-impersonate.patch
+++ b/patch/curl-impersonate.patch
@@ -2543,6 +2543,21 @@ index f24cb6924..30b4fdb0a 100644
  endif
  
  # if unit tests are enabled, build a static library to link them with
+diff --git a/src/tool_cfgable.c b/src/tool_cfgable.c
+index ec5698ba2..7ca57f0d4 100644
+--- a/src/tool_cfgable.c
++++ b/src/tool_cfgable.c
+@@ -172,6 +172,10 @@ static void free_config_fields(struct OperationConfig *config)
+   Curl_safefree(config->aws_sigv4);
+   Curl_safefree(config->proto_str);
+   Curl_safefree(config->proto_redir_str);
++
++  Curl_safefree(config->ssl_sig_hash_algs);
++  Curl_safefree(config->ssl_cert_compression);
++  Curl_safefree(config->http2_pseudo_headers_order);
+ }
+ 
+ void config_free(struct OperationConfig *config)
 diff --git a/src/tool_cfgable.h b/src/tool_cfgable.h
 index 9a15659bc..7bf73bd3b 100644
 --- a/src/tool_cfgable.h

--- a/patch_curl.bat
+++ b/patch_curl.bat
@@ -4,6 +4,7 @@ set sed=c:\msys64\usr\bin\sed.exe
 cd %~dp0curl
 
 %patch% -p1 < %~dp0patch\curl-impersonate.patch
+%patch% -p1 < %~dp0patch\curl-CVE-2023-38545.patch
 
 %sed% -i 's/-shared/-s -static -shared/g' lib\Makefile.mk
 %sed% -i 's/-DUSE_NGHTTP2/-DUSE_NGHTTP2 -DNGHTTP2_STATICLIB -DUSE_WEBSOCKETS/g' lib\Makefile.mk


### PR DESCRIPTION
I've applied the memory leak fix and CVE-2023-38545 patches from the main `curl-impersonate` repository.

I haven't applied the new BoringSSL patches though, because they pertain to a newer version of BoringSSL that I was struggling to get to compile with the current build configuration.